### PR TITLE
Get ok from ping only once

### DIFF
--- a/src/MongoDB.HealthCheck/MongoHealthCheck.cs
+++ b/src/MongoDB.HealthCheck/MongoHealthCheck.cs
@@ -39,9 +39,9 @@ namespace MongoDB.HealthCheck
 				// Mongo has different response types with ping
 				// Sometimes ok is 1.0 other times it is 1
 				// Handle both cases correctly
-				if (ping.Contains("ok") &&
-					(ping["ok"].IsDouble && Convert.ToDecimal(ping["ok"].AsDouble) == 1m ||
-					 ping["ok"].IsInt32 && ping["ok"].AsInt32 == 1))
+				if (ping.TryGetValue("ok", out var ok) &&
+					((ok.IsDouble && Math.Abs(ok.AsDouble - 1.0) < double.Epsilon) ||
+					 (ok.IsInt32 && ok.AsInt32 == 1)))
 				{
 					// Return health check value based on cluster state
 					// This works whether connecting to a single server


### PR DESCRIPTION
Hi! Please review my small improvement:-)

We're can get `ok` from `ping` dictionary only once per `HealthCheckAsync` instead of three or four times (one time calling Contains and two or more times calling `ping["ok"]` indexer) and avoid cast it to decimal